### PR TITLE
feat: add single CIS filter support (-F) and display upgradable packages count

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ get_if_addrs  = "0.5"
 os_info = "3"
 clap = { version = "4.5.4", features = ["derive"] }
 roxmltree = "0.20.0"
-
-[alias]
-check-pedantic = "clippy -- -D warnings -W clippy::pedantic"

--- a/src/audit_rules/exec_command.rs
+++ b/src/audit_rules/exec_command.rs
@@ -20,14 +20,14 @@ use std::process::Command;
 /// - If the output is not `"0"`, `"1"`, or empty.
 /// - If the exit code is not `0` or `1` when no output is produced.
 pub fn execute_verification_command(cmd: &str) -> Result<bool, String> {
-    let output = Command::new("sh")
+    let output: std::process::Output = Command::new("sh")
         .arg("-c")
         .arg(cmd)
         .output()
         .map_err(|e| format!("Erreur système : {e}"))?;
 
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout: String = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr: String = String::from_utf8_lossy(&output.stderr).trim().to_string();
 
     // Treat any message on stderr as an immediate error.
     if !stderr.is_empty() {

--- a/src/audit_rules/rule.rs
+++ b/src/audit_rules/rule.rs
@@ -56,7 +56,7 @@ impl<'de> Deserialize<'de> for CompliantStatus {
     where
         D: Deserializer<'de>,
     {
-        let s = String::deserialize(de)?;
+        let s: String = String::deserialize(de)?;
         CompliantStatus::from_str(&s)
             .ok_or_else(|| de::Error::custom(format!("invalid compliance value: {s}")))
     }
@@ -84,6 +84,7 @@ pub struct Profile {
     #[serde(rename = "@level")]
     pub level: String,
     #[serde(rename = "@type")]
+    #[serde(default)]
     pub r#type: String,
 }
 

--- a/src/audit_rules/scanner.rs
+++ b/src/audit_rules/scanner.rs
@@ -37,8 +37,8 @@ pub enum ScanError {
 /// Convert any serialisable value to a pretty-printed XML string
 /// using four spaces per indentation level.
 pub fn pretty_xml<T: Serialize>(value: &T) -> Result<String, ScanError> {
-    let mut buf = String::new();
-    let mut ser = Serializer::new(&mut buf);
+    let mut buf: String = String::new();
+    let mut ser: Serializer<'_, '_, String> = Serializer::new(&mut buf);
     ser.indent(' ', 4);
     value.serialize(ser)?;
     Ok(buf)
@@ -60,12 +60,12 @@ pub fn scan_directory(dir: &str) -> Result<(), ScanError> {
         .collect();
     files.sort_by_key(DirEntry::file_name);
 
-    let mut global = RulesCis::default();
+    let mut global: RulesCis = RulesCis::default();
 
     for file in files {
-        let raw = fs::read_to_string(file.path())?;
+        let raw: String = fs::read_to_string(file.path())?;
 
-        let local = match from_str::<RulesCis>(&raw) {
+        let local: RulesCis = match from_str::<RulesCis>(&raw) {
             Ok(r) => r,
             Err(e) => {
                 eprintln!("Erreur XML dans «{}» : {}", file.path().display(), e);
@@ -87,16 +87,16 @@ pub fn scan_directory(dir: &str) -> Result<(), ScanError> {
         }
     }
 
-    let xml = pretty_xml(&global)?;
+    let xml: String = pretty_xml(&global)?;
 
     fs::create_dir_all("reports")?;
   
-    let folder_name = Path::new(dir)
+    let folder_name: &str = Path::new(dir)
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("output");
 
-    let file_path = format!("reports/{folder_name}_cis_result.xml");
+    let file_path: String = format!("reports/{folder_name}_cis_result.xml");
     fs::write(&file_path, xml)?;
 
     println!("Report written to {file_path}");
@@ -112,15 +112,15 @@ pub fn scan_directory(dir: &str) -> Result<(), ScanError> {
 /// # Returns
 /// A list of rule names for which a corresponding package was found.
 pub fn load_installed_packages(packages_path: &str) -> anyhow::Result<Vec<String>> {
-    let rules_dir = fs::read_dir("rules")?;
-    let file = File::open(packages_path)?;
-    let reader = BufReader::new(file);
+    let rules_dir: fs::ReadDir = fs::read_dir("rules")?;
+    let file: File = File::open(packages_path)?;
+    let reader: BufReader<File> = BufReader::new(file);
 
-    let mut installed = Vec::new();
+    let mut installed: Vec<String> = Vec::new();
     let lines: Vec<_> = reader.lines().flatten().collect();
 
     for entry in rules_dir.flatten() {
-        let rule_dir = entry.path();
+        let rule_dir: std::path::PathBuf = entry.path();
         if !rule_dir.is_dir() {
             continue;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use audity::controller;
 use clap::{Arg, ArgAction, Command};
 
 fn main() {
-    let matches = Command::new("Audity")
+    let matches: clap::ArgMatches = Command::new("Audity")
         .version("0.1.0")
         .author("DyDum & Wikkizs")
         .about("Linux server scanning and auditing tool")
@@ -15,21 +15,29 @@ fn main() {
         .arg(Arg::new("update").short('D').long("update").help("Update package list (Must be sudo)").action(ArgAction::SetTrue).requires("package"))
         .arg(Arg::new("upgrade").short('G').long("upgrade").help("Check upgrades").action(ArgAction::SetTrue).requires("package"))
         .arg(Arg::new("cis").short('C').long("cis").help("Check CIS compliances (MUST HAVE PACKAGE LIST)").action(ArgAction::SetTrue).requires("package"))
+        .arg(Arg::new("list").short('L').long("list").help("List all CIS available in audity").action(ArgAction::SetTrue).requires("cis"))
+        .arg(Arg::new("filter").short('F').long("filter").help("Filter the audit to a specific package").num_args(1).value_name("CIS_NAME").requires("cis"))
         .arg(Arg::new("correction").short('R').long("correction").help("Correct all packages for CIS compliances (MUST HAVE PACKAGE LIST) (Must be sudo)").action(ArgAction::SetTrue))
         .get_matches();
+
+    let do_update: bool = matches.get_flag("update");
+    let do_upgrade: bool = matches.get_flag("upgrade");
 
     if matches.get_flag("audit") {
         controller::run_full_audit();
     } else if matches.get_flag("cis") {
-        controller::run_audit_rules();
-        let do_update = matches.get_flag("update");
-        let do_upgrade = matches.get_flag("upgrade");
-        controller::run_package_audit(do_update, do_upgrade);
+        if matches.get_flag("list") {
+            controller::list_cis();
+        }else {
+            controller::run_package_audit(do_update, do_upgrade);
+
+            let filter: Option<&str> = matches.get_one::<String>("filter").map(|s| s.as_str());
+            controller::run_audit_rules(filter);
+        }
+        
     } else if matches.get_flag("correction") {
         controller::run_correction();
     } else if matches.get_flag("package") {
-        let do_update = matches.get_flag("update");
-        let do_upgrade = matches.get_flag("upgrade");
         controller::run_package_audit(do_update, do_upgrade);
     }
 }

--- a/src/package_management/correction.rs
+++ b/src/package_management/correction.rs
@@ -14,10 +14,10 @@ pub fn correct_directory(dir: &str) -> anyhow::Result<()> {
         .collect();
     files.sort_by_key(|e| e.file_name());
 
-    let mut global = RulesCis::default();
+    let mut global: RulesCis = RulesCis::default();
 
     for file in files {
-        let raw = fs::read_to_string(file.path())?;
+        let raw: String = fs::read_to_string(file.path())?;
         let local: RulesCis = from_str(&raw)?;
 
         for mut rule in local.rules {
@@ -27,13 +27,13 @@ pub fn correct_directory(dir: &str) -> anyhow::Result<()> {
                         Ok(true) => CompliantStatus::Yes,
                         Ok(false) | Err(_) => {
                             // 🚫 Filtrage des règles à haut risque
-                            let risky = rule.id.starts_with("1.1.")
+                            let risky: bool = rule.id.starts_with("1.1.")
                                 || rule.correction.contains("/usr/lib")
                                 || rule.correction.contains("/usr/bin")
                                 || rule.correction.contains("chmod -R");
 
                             if risky {
-                                println!("Rule {} of file {} skipped: too risky", rule.id, file.file_name().to_string_lossy());
+                                println!("Rule {} of package {} skipped: too risky", rule.id, dir.to_string());
                                 CompliantStatus::NotTested
                             } else {
                                 let _ = execute_verification_command(&rule.correction);
@@ -54,15 +54,15 @@ pub fn correct_directory(dir: &str) -> anyhow::Result<()> {
     }
 
 
-    let xml = pretty_xml(&global)?;
+    let xml: String = pretty_xml(&global)?;
     fs::create_dir_all("reports")?;
 
-    let folder_name = Path::new(dir)
+    let folder_name: &str = Path::new(dir)
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("output");
 
-    let file_path = format!("reports/{}_correction.xml", folder_name);
+    let file_path: String = format!("reports/{}_correction.xml", folder_name);
     fs::write(&file_path, xml)?;
 
     println!("Correction report written to {}", file_path);

--- a/src/package_management/list.rs
+++ b/src/package_management/list.rs
@@ -14,7 +14,7 @@ use std::fmt::Write;
 /// - The `dpkg -l` command fails to execute (e.g. `dpkg` not found).
 /// - The command executes but returns a non-zero exit code.
 pub fn get_installed_packages_count() -> Result<usize, std::io::Error> {
-    let output = Command::new("dpkg")
+    let output: std::process::Output = Command::new("dpkg")
         .arg("-l")
         .output()?;
 
@@ -39,23 +39,23 @@ pub fn get_installed_packages_count() -> Result<usize, std::io::Error> {
 /// - The command output is not valid UTF-8.
 /// - There is an internal formatting failure when building the result string.
 pub fn list_installed_packages() -> Result<String, IoError> {
-    let output = Command::new("dpkg")
+    let output: std::process::Output = Command::new("dpkg")
         .arg("-l")
         .output()?;
 
     if output.status.success() {
         // Convert bytes to string and handle UTF-8 conversion errors
-        let output_str = str::from_utf8(&output.stdout)
+        let output_str: &str = str::from_utf8(&output.stdout)
             .map_err(|e| IoError::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         // Parse and collect package details
-        let mut details = String::new();
+        let mut details: String = String::new();
         for line in output_str.lines().skip(5) { // Skipping header lines
             let parts: Vec<&str> = line.split_whitespace().collect();
             if parts.len() > 3 {
-                let package_name = parts[1];
-                let version = parts[2];
-                let architecture = parts[3];
+                let package_name: &str = parts[1];
+                let version: &str = parts[2];
+                let architecture: &str = parts[3];
                 if let Err(e) = writeln!(details, "{package_name} {version} {architecture}") {
                     return Err(IoError::new(io::ErrorKind::Other, e.to_string()));
                 }

--- a/src/package_management/update.rs
+++ b/src/package_management/update.rs
@@ -14,7 +14,7 @@ use std::fs::File;
 /// - The command `sudo apt update` cannot be executed (e.g. missing `sudo` or `apt`).
 /// - The command returns a non-zero exit code.
 pub fn update_package_list() -> Result<(), io::Error> {
-    let status = Command::new("sudo")
+    let status: std::process::ExitStatus = Command::new("sudo")
         .arg("apt")
         .arg("update")
         .arg("-qq") // Use -qq for quiet mode, suppressing output unless there's an error
@@ -40,8 +40,8 @@ pub fn update_package_list() -> Result<(), io::Error> {
 /// - The command returns a non-zero exit code.
 /// - The command output is not valid UTF-8.
 /// - An error message is emitted to stderr.
-pub fn check_upgradable_packages() -> Result<String, IoError> {
-    let output = Command::new("apt")
+pub fn check_upgradable_packages() -> Result<Vec<String>, IoError> {
+    let output: std::process::Output = Command::new("apt")
         .arg("list")
         .arg("--upgradable")
         .arg("-qq") // Use -qq for quiet mode, suppressing output unless there's an error
@@ -53,12 +53,12 @@ pub fn check_upgradable_packages() -> Result<String, IoError> {
             .map_err(|e| IoError::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         // Skip the first line of the output, usually a header.
-        let packages_details = upgradable_packages.lines().skip(1).collect::<Vec<_>>().join("\n");
+        let packages_details: Vec<String> = upgradable_packages.lines().skip(1).map(|line| line.to_string()).collect();
 
         Ok(packages_details)
     } else {
         // Decode the error message and return it as an IoError.
-        let error_message = str::from_utf8(&output.stderr)
+        let error_message: String = str::from_utf8(&output.stderr)
             .unwrap_or("Failed to decode error message")  // Provide a fallback error message.
             .to_string();
         

--- a/src/package_management/xml_report.rs
+++ b/src/package_management/xml_report.rs
@@ -24,7 +24,7 @@ pub fn generate_xml_report(
     upgradable_packages: &str,
 ) -> Result<String> {
     // Initialize the writer with 4-space indentation, writing to memory buffer.
-    let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 4);
+    let mut writer: Writer<Cursor<Vec<u8>>> = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 4);
 
     // Closure to convert quick_xml errors into IoError.
     let map_err = |e: quick_xml::Error| IoError::new(ErrorKind::Other, e.to_string());
@@ -50,7 +50,7 @@ pub fn generate_xml_report(
         let details: Vec<&str> = line.split_whitespace().collect(); // Expect: name + version
         if details.len() > 1 {
             // Write <package name="..." version="..." />.
-            let mut pkg = BytesStart::new("package");
+            let mut pkg: BytesStart<'_> = BytesStart::new("package");
             pkg.push_attribute(("name", details[0]));
             pkg.push_attribute(("version", details[1]));
             writer.write_event(Event::Empty(pkg)).map_err(map_err)?;
@@ -64,7 +64,7 @@ pub fn generate_xml_report(
         let details: Vec<&str> = line.split_whitespace().collect(); // Expect: name only
         if !details.is_empty() {
             // Write <package name="..." />.
-            let mut pkg = BytesStart::new("package");
+            let mut pkg: BytesStart<'_> = BytesStart::new("package");
             pkg.push_attribute(("name", details[0]));
             writer.write_event(Event::Empty(pkg)).map_err(map_err)?;
         }
@@ -75,6 +75,6 @@ pub fn generate_xml_report(
     writer.write_event(Event::End(BytesEnd::new("packages"))).map_err(map_err)?;
 
     // Convert the memory buffer (Vec<u8>) into UTF-8 string and return.
-    let output = writer.into_inner().into_inner();
+    let output: Vec<u8> = writer.into_inner().into_inner();
     String::from_utf8(output).map_err(|e| IoError::new(ErrorKind::InvalidData, e))
 }


### PR DESCRIPTION
feat: add single CIS filter support (-F) and display upgradable packages count

- Added ability to filter audit on a specific CIS using -F with formatted name
- Displayed number of upgradable packages and listed them in audit output
- Typed all `let` bindings explicitly for clarity and consistency